### PR TITLE
Fix readme showing L instead of R

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ With full saving capabilites and HD textures, you'll have a blast!
 Movement: Arrow Keys <br>
 A: X <br>
 B: C <br>
-L: Q <br>
+R: Q <br>
 Z: Space <br>
 Start: Enter <br>
 C-stick: WASD


### PR DESCRIPTION
R is the button that controls "Mario Camera" and freezing the camera.